### PR TITLE
v3.0.0.0: Jellyfin 10.11+ support, configurable roles & library sync

### DIFF
--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -10,12 +10,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - name: "Setup .NET Core"
-        uses: actions/setup-dotnet@v1
+      - name: "Setup .NET"
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "6.0.x"
+          dotnet-version: "9.0.x"
 
       - name: "Install dependencies"
         run: dotnet restore

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 bin/
 obj/
+publish/
 .idea/
-*.DotSettings.user
 .vs/
+*.DotSettings.user

--- a/Jellyfin.Plugin.Keycloak/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.Keycloak/Configuration/PluginConfiguration.cs
@@ -3,7 +3,23 @@ using MediaBrowser.Model.Plugins;
 namespace Jellyfin.Plugin.Keycloak.Configuration;
 
 /// <summary>
-/// The main plugin.
+/// Role source options.
+/// </summary>
+public enum RoleSource
+{
+    /// <summary>
+    /// Read roles from resource_access.{client}.roles (Client Roles).
+    /// </summary>
+    ClientRoles = 0,
+
+    /// <summary>
+    /// Read roles from realm_access.roles (Realm Roles).
+    /// </summary>
+    RealmRoles = 1
+}
+
+/// <summary>
+/// Plugin configuration.
 /// </summary>
 public class PluginConfiguration : BasePluginConfiguration
 {
@@ -12,42 +28,101 @@ public class PluginConfiguration : BasePluginConfiguration
     /// </summary>
     public PluginConfiguration()
     {
-        // set default options here
-        this.CreateUser = true;
-        this.Enable2Fa = false;
+        // Keycloak Connection
         this.AuthServerUrl = string.Empty;
         this.Realm = string.Empty;
         this.Resource = string.Empty;
         this.ClientSecret = string.Empty;
+
+        // User Settings
+        this.CreateUser = true;
+        this.Enable2Fa = false;
+
+        // Role Configuration (defaults for backwards compatibility)
+        this.RoleSource = RoleSource.ClientRoles;
+        this.RoleSourceClient = "jellyfin";
+
+        // Permission Mapping (defaults match old plugin behavior)
+        this.AdminRole = string.Empty; // Legacy field, migrated to AdminRoles
+        this.AdminRoles = "administrator";
+        this.AllowedAccessRoles = "allowed_access";
+        this.DownloadRoles = "allow_media_downloads";
+
+        // Library Sync
+        this.EnableLibrarySync = false;
+        this.LibraryRoleMapping = string.Empty;
     }
 
     /// <summary>
-    /// Gets or sets a value indicating whether an user from keycloak exists Jellyfin.
-    /// </summary>
-    public bool CreateUser { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether an user from keycloak exists Jellyfin.
-    /// </summary>
-    public bool Enable2Fa { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether an user from keycloak exists Jellyfin.
+    /// Gets or sets the Keycloak auth server URL.
     /// </summary>
     public string AuthServerUrl { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether an user from keycloak exists Jellyfin.
+    /// Gets or sets the Keycloak realm.
     /// </summary>
     public string Realm { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether an user from keycloak exists Jellyfin.
+    /// Gets or sets the Keycloak resource/client ID for authentication.
     /// </summary>
     public string Resource { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether an user from keycloak exists Jellyfin.
+    /// Gets or sets the client secret.
     /// </summary>
     public string ClientSecret { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to create users automatically.
+    /// </summary>
+    public bool CreateUser { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether 2FA is enabled.
+    /// </summary>
+    public bool Enable2Fa { get; set; }
+
+    /// <summary>
+    /// Gets or sets the role source (Client Roles or Realm Roles).
+    /// </summary>
+    public RoleSource RoleSource { get; set; }
+
+    /// <summary>
+    /// Gets or sets the client name for reading client roles.
+    /// Only used when RoleSource is ClientRoles.
+    /// </summary>
+    public string RoleSourceClient { get; set; }
+
+    /// <summary>
+    /// Gets or sets the admin role (legacy, use AdminRoles instead).
+    /// Kept for backwards compatibility with older configs.
+    /// </summary>
+    public string AdminRole { get; set; }
+
+    /// <summary>
+    /// Gets or sets the roles that grant Jellyfin administrator status (comma-separated).
+    /// </summary>
+    public string AdminRoles { get; set; }
+
+    /// <summary>
+    /// Gets or sets the roles that allow login to Jellyfin (comma-separated).
+    /// </summary>
+    public string AllowedAccessRoles { get; set; }
+
+    /// <summary>
+    /// Gets or sets the roles that allow media downloads (comma-separated).
+    /// </summary>
+    public string DownloadRoles { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether library access should be synced based on roles.
+    /// </summary>
+    public bool EnableLibrarySync { get; set; }
+
+    /// <summary>
+    /// Gets or sets the JSON mapping of library IDs to required roles.
+    /// Format: {"libraryId": "role1,role2", ...}
+    /// </summary>
+    public string LibraryRoleMapping { get; set; }
 }

--- a/Jellyfin.Plugin.Keycloak/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Keycloak/Configuration/configPage.html
@@ -9,40 +9,100 @@
     <div data-role="content">
         <div class="content-primary">
             <form id="TemplateConfigForm">
-                <div class="checkboxContainer checkboxContainer-withDescription">
-                    <label class="emby-checkbox-label">
-                        <input id="Enable2FA" name="TrueFalseCheckBox" type="checkbox" is="emby-checkbox"/>
-                        <span>Enable2FA</span>
-                    </label>
-                    <div class="fieldDescription">BIGHACK: add _2FA=CODEHERE to end of password when loging in</div>
-                </div>
-                <div class="checkboxContainer checkboxContainer-withDescription">
-                    <label class="emby-checkbox-label">
-                        <input id="CreateUser" name="TrueFalseCheckBox" type="checkbox" is="emby-checkbox"/>
-                        <span>Create User if doesn't exist</span>
-                    </label>
-                </div>
+                <h2>Keycloak Connection</h2>
                 <div class="inputContainer">
                     <label class="inputLabel inputLabelUnfocused" for="AuthServerUrl">Auth Server URL</label>
                     <input id="AuthServerUrl" name="AuthServerUrl" type="text" is="emby-input"/>
-                    <div class="fieldDescription">Base Keycloak auth URI</div>
+                    <div class="fieldDescription">Base Keycloak auth URI (e.g., https://auth.example.com/auth)</div>
                 </div>
                 <div class="inputContainer">
-                    <label class="inputeLabel inputLabelUnfocused" for="Realm">Realm</label>
-                    <input id="Realm" name="AString" type="text" is="emby-input"/>
+                    <label class="inputLabel inputLabelUnfocused" for="Realm">Realm</label>
+                    <input id="Realm" name="Realm" type="text" is="emby-input"/>
                     <div class="fieldDescription">Keycloak Realm</div>
                 </div>
                 <div class="inputContainer">
-                    <label class="inputeLabel inputLabelUnfocused" for="Resource">Resource/Client</label>
-                    <input id="Resource" name="AString" type="text" is="emby-input"/>
-                    <div class="fieldDescription">Keycloak Resource/Client</div>
+                    <label class="inputLabel inputLabelUnfocused" for="Resource">Resource/Client ID</label>
+                    <input id="Resource" name="Resource" type="text" is="emby-input"/>
+                    <div class="fieldDescription">Keycloak Client ID for authentication (Direct Access Grants)</div>
                 </div>
                 <div class="inputContainer">
-                    <label class="inputeLabel inputLabelUnfocused" for="ClientSecret">Client Secret</label>
-                    <input id="ClientSecret" name="AString" type="text" is="emby-input"/>
-                    <div class="fieldDescription">Client Secret</div>
+                    <label class="inputLabel inputLabelUnfocused" for="ClientSecret">Client Secret</label>
+                    <input id="ClientSecret" name="ClientSecret" type="password" is="emby-input"/>
+                    <div class="fieldDescription">Client Secret (leave empty for public clients)</div>
                 </div>
-                <div>
+
+                <h2>User Settings</h2>
+                <div class="checkboxContainer checkboxContainer-withDescription">
+                    <label class="emby-checkbox-label">
+                        <input id="CreateUser" name="CreateUser" type="checkbox" is="emby-checkbox"/>
+                        <span>Create user if doesn't exist</span>
+                    </label>
+                    <div class="fieldDescription">Automatically create Jellyfin user on first Keycloak login</div>
+                </div>
+                <div class="checkboxContainer checkboxContainer-withDescription">
+                    <label class="emby-checkbox-label">
+                        <input id="Enable2FA" name="Enable2FA" type="checkbox" is="emby-checkbox"/>
+                        <span>Enable 2FA</span>
+                    </label>
+                    <div class="fieldDescription">Append _2FA=CODE to password when logging in</div>
+                </div>
+
+                <h2>Role Configuration</h2>
+                <div class="selectContainer">
+                    <label class="selectLabel" for="RoleSource">Role Source</label>
+                    <select id="RoleSource" is="emby-select">
+                        <option value="ClientRoles">Client Roles (resource_access.{client}.roles)</option>
+                        <option value="RealmRoles">Realm Roles (realm_access.roles)</option>
+                    </select>
+                    <div class="fieldDescription">Where to read roles from in the Keycloak token</div>
+                </div>
+                <div id="clientRoleSourceContainer" class="inputContainer">
+                    <label class="inputLabel inputLabelUnfocused" for="RoleSourceClient">Client Name for Roles</label>
+                    <input id="RoleSourceClient" name="RoleSourceClient" type="text" is="emby-input"/>
+                    <div class="fieldDescription">Client name to read roles from (usually same as Resource/Client ID)</div>
+                </div>
+
+                <h2>Permission Mapping</h2>
+                <div class="fieldDescription" style="margin-bottom: 15px;">
+                    Map Keycloak roles to Jellyfin permissions. Enter comma-separated role names.
+                </div>
+                <div class="inputContainer">
+                    <label class="inputLabel inputLabelUnfocused" for="AllowedAccessRoles">Allowed Access Roles</label>
+                    <input id="AllowedAccessRoles" name="AllowedAccessRoles" type="text" is="emby-input"/>
+                    <div class="fieldDescription">Users with these roles can log in to Jellyfin</div>
+                </div>
+                <div class="inputContainer">
+                    <label class="inputLabel inputLabelUnfocused" for="AdminRoles">Admin Roles</label>
+                    <input id="AdminRoles" name="AdminRoles" type="text" is="emby-input"/>
+                    <div class="fieldDescription">Users with these roles become Jellyfin administrators</div>
+                </div>
+                <div class="inputContainer">
+                    <label class="inputLabel inputLabelUnfocused" for="DownloadRoles">Download Roles</label>
+                    <input id="DownloadRoles" name="DownloadRoles" type="text" is="emby-input"/>
+                    <div class="fieldDescription">Users with these roles can download media</div>
+                </div>
+
+                <h2>Library Access Sync</h2>
+                <div class="checkboxContainer checkboxContainer-withDescription">
+                    <label class="emby-checkbox-label">
+                        <input id="EnableLibrarySync" name="EnableLibrarySync" type="checkbox" is="emby-checkbox"/>
+                        <span>Enable library access sync</span>
+                    </label>
+                    <div class="fieldDescription">Sync library access based on Keycloak roles on each login</div>
+                </div>
+
+                <div id="libraryMappingContainer" style="display: none; margin-top: 20px;">
+                    <h3>Library Role Mapping</h3>
+                    <div class="fieldDescription" style="margin-bottom: 15px;">
+                        For each library, enter comma-separated roles that should have access.
+                        Leave empty to not manage that library (user keeps manual settings).
+                    </div>
+                    <div id="libraryList">
+                        <div class="fieldDescription">Loading libraries...</div>
+                    </div>
+                </div>
+
+                <div style="margin-top: 20px;">
                     <button is="emby-button" type="submit" class="raised button-submit block emby-button">
                         <span>Save</span>
                     </button>
@@ -53,43 +113,156 @@
     <script type="text/javascript">
         var KeycloakPluginConfig = {
             pluginUniqueId: '40886866-b3dd-4d6a-bf9b-25c83e6c3d10',
-            chkCreateUser: document.querySelector('#CreateUser'),
-            txtAuthServerUrl: document.querySelector('#AuthServerUrl'),
-            txtRealm: document.querySelector('#Realm'),
-            txtResource: document.querySelector('#Resource'),
-            txtClientSecret: document.querySelector('#ClientSecret'),
-            chkEnable2FA: document.querySelector('#Enable2FA'),
+            libraryMapping: {},
+            libraries: []
         };
+
+        function loadLibraries() {
+            return ApiClient.getVirtualFolders().then(function(folders) {
+                KeycloakPluginConfig.libraries = folders;
+                return folders;
+            });
+        }
+
+        function renderLibraryMapping() {
+            var container = document.querySelector('#libraryList');
+            var libraries = KeycloakPluginConfig.libraries;
+            var mapping = KeycloakPluginConfig.libraryMapping;
+
+            if (!libraries || libraries.length === 0) {
+                container.innerHTML = '<div class="fieldDescription">No libraries found</div>';
+                return;
+            }
+
+            var html = '';
+            for (var i = 0; i < libraries.length; i++) {
+                var lib = libraries[i];
+                var libId = lib.ItemId;
+                var roles = mapping[libId] || '';
+
+                html += '<div class="inputContainer">';
+                html += '<label class="inputLabel inputLabelUnfocused" for="lib_' + libId + '">' + lib.Name + '</label>';
+                html += '<input id="lib_' + libId + '" data-library-id="' + libId + '" type="text" is="emby-input" class="libraryRoleInput" value="' + roles + '"/>';
+                html += '</div>';
+            }
+
+            container.innerHTML = html;
+        }
+
+        function collectLibraryMapping() {
+            var mapping = {};
+            var inputs = document.querySelectorAll('.libraryRoleInput');
+            for (var i = 0; i < inputs.length; i++) {
+                var input = inputs[i];
+                var libId = input.getAttribute('data-library-id');
+                var roles = input.value.trim();
+                if (roles) {
+                    mapping[libId] = roles;
+                }
+            }
+            return JSON.stringify(mapping);
+        }
+
+        function toggleLibraryMapping() {
+            var container = document.querySelector('#libraryMappingContainer');
+            var checkbox = document.querySelector('#EnableLibrarySync');
+            container.style.display = checkbox.checked ? 'block' : 'none';
+
+            if (checkbox.checked && KeycloakPluginConfig.libraries.length === 0) {
+                loadLibraries().then(renderLibraryMapping);
+            }
+        }
+
+        function toggleRoleSourceClient() {
+            var container = document.querySelector('#clientRoleSourceContainer');
+            var select = document.querySelector('#RoleSource');
+            container.style.display = select.value === 'ClientRoles' ? 'block' : 'none';
+        }
 
         document.querySelector('#TemplateConfigPage')
             .addEventListener('pageshow', function () {
                 Dashboard.showLoadingMsg();
-                ApiClient.getPluginConfiguration(KeycloakPluginConfig.pluginUniqueId).then(function (config) {
-                    KeycloakPluginConfig.chkCreateUser.checked = config.CreateUser;
-                    KeycloakPluginConfig.txtAuthServerUrl.value = config.AuthServerUrl;
-                    KeycloakPluginConfig.txtRealm.value = config.Realm;
-                    KeycloakPluginConfig.txtResource.value = config.Resource;
-                    KeycloakPluginConfig.txtClientSecret.value = config.ClientSecret;
-                    KeycloakPluginConfig.chkEnable2FA.checked = config.Enable2FA;
+
+                Promise.all([
+                    ApiClient.getPluginConfiguration(KeycloakPluginConfig.pluginUniqueId),
+                    loadLibraries()
+                ]).then(function(results) {
+                    var config = results[0];
+
+                    // Keycloak Connection
+                    document.querySelector('#AuthServerUrl').value = config.AuthServerUrl || '';
+                    document.querySelector('#Realm').value = config.Realm || '';
+                    document.querySelector('#Resource').value = config.Resource || '';
+                    document.querySelector('#ClientSecret').value = config.ClientSecret || '';
+
+                    // User Settings
+                    document.querySelector('#CreateUser').checked = config.CreateUser;
+                    document.querySelector('#Enable2FA').checked = config.Enable2Fa;
+
+                    // Role Configuration
+                    document.querySelector('#RoleSource').value = config.RoleSource === 1 ? 'RealmRoles' : 'ClientRoles';
+                    document.querySelector('#RoleSourceClient').value = config.RoleSourceClient || 'jellyfin';
+
+                    // Permission Mapping (with legacy AdminRole migration)
+                    var adminRolesValue = config.AdminRoles || config.AdminRole || 'administrator';
+                    document.querySelector('#AdminRoles').value = adminRolesValue;
+                    document.querySelector('#AllowedAccessRoles').value = config.AllowedAccessRoles || 'allowed_access';
+                    document.querySelector('#DownloadRoles').value = config.DownloadRoles || 'allow_media_downloads';
+
+                    // Library Sync
+                    document.querySelector('#EnableLibrarySync').checked = config.EnableLibrarySync;
+
+                    try {
+                        KeycloakPluginConfig.libraryMapping = config.LibraryRoleMapping ? JSON.parse(config.LibraryRoleMapping) : {};
+                    } catch (e) {
+                        KeycloakPluginConfig.libraryMapping = {};
+                    }
+
+                    renderLibraryMapping();
+                    toggleLibraryMapping();
+                    toggleRoleSourceClient();
+
                     Dashboard.hideLoadingMsg();
                 });
             });
+
+        document.querySelector('#EnableLibrarySync').addEventListener('change', toggleLibraryMapping);
+        document.querySelector('#RoleSource').addEventListener('change', toggleRoleSourceClient);
 
         document.querySelector('#TemplateConfigForm')
             .addEventListener('submit', function (e) {
                 e.preventDefault();
                 Dashboard.showLoadingMsg();
+
                 ApiClient.getPluginConfiguration(KeycloakPluginConfig.pluginUniqueId).then(function (config) {
-                    config.CreateUser = KeycloakPluginConfig.chkCreateUser.checked;
-                    config.AuthServerUrl = KeycloakPluginConfig.txtAuthServerUrl.value;
-                    config.Realm = KeycloakPluginConfig.txtRealm.value;
-                    config.Resource = KeycloakPluginConfig.txtResource.value;
-                    config.ClientSecret = KeycloakPluginConfig.txtClientSecret.value;
-                    config.Enable2FA = KeycloakPluginConfig.chkEnable2FA.checked;
+                    // Keycloak Connection
+                    config.AuthServerUrl = document.querySelector('#AuthServerUrl').value;
+                    config.Realm = document.querySelector('#Realm').value;
+                    config.Resource = document.querySelector('#Resource').value;
+                    config.ClientSecret = document.querySelector('#ClientSecret').value;
+
+                    // User Settings
+                    config.CreateUser = document.querySelector('#CreateUser').checked;
+                    config.Enable2Fa = document.querySelector('#Enable2FA').checked;
+
+                    // Role Configuration
+                    config.RoleSource = document.querySelector('#RoleSource').value === 'RealmRoles' ? 1 : 0;
+                    config.RoleSourceClient = document.querySelector('#RoleSourceClient').value;
+
+                    // Permission Mapping
+                    config.AdminRoles = document.querySelector('#AdminRoles').value;
+                    config.AllowedAccessRoles = document.querySelector('#AllowedAccessRoles').value;
+                    config.DownloadRoles = document.querySelector('#DownloadRoles').value;
+
+                    // Library Sync
+                    config.EnableLibrarySync = document.querySelector('#EnableLibrarySync').checked;
+                    config.LibraryRoleMapping = collectLibraryMapping();
+
                     ApiClient.updatePluginConfiguration(KeycloakPluginConfig.pluginUniqueId, config).then(function (result) {
                         Dashboard.processPluginConfigurationUpdateResult(result);
                     });
                 });
+
                 return false;
             });
     </script>

--- a/Jellyfin.Plugin.Keycloak/Jellyfin.Plugin.Keycloak.csproj
+++ b/Jellyfin.Plugin.Keycloak/Jellyfin.Plugin.Keycloak.csproj
@@ -1,32 +1,27 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <AssemblyVersion>2.0.0.0</AssemblyVersion>
-    <FileVersion>2.0.0.0</FileVersion>
+    <TargetFramework>net9.0</TargetFramework>
+    <AssemblyVersion>2.1.0.0</AssemblyVersion>
+    <FileVersion>2.1.0.0</FileVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>../jellyfin.ruleset</CodeAnalysisRuleSet>
-    <NoWarn>CA1819</NoWarn>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <NoWarn>CA1819;SA1210;CS1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.*-*" />
-    <PackageReference Include="Jellyfin.Model" Version="10.*-*" />
+    <PackageReference Include="Jellyfin.Controller" Version="10.11.*">
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
+    <PackageReference Include="Jellyfin.Model" Version="10.11.*">
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
     <PackageReference Include="JWT" Version="8.1.3" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
-  </ItemGroup>
-
-  <!-- Code Analyzers-->
-  <ItemGroup>
-    <PackageReference Include="SerilogAnalyzer" Version="0.15.0" PrivateAssets="All" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
-    <PackageReference Include="SmartAnalyzers.MultithreadingAnalyzer" Version="1.1.31" PrivateAssets="All" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jellyfin.Plugin.Keycloak/Jellyfin.Plugin.Keycloak.csproj
+++ b/Jellyfin.Plugin.Keycloak/Jellyfin.Plugin.Keycloak.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
-    <AssemblyVersion>2.1.0.0</AssemblyVersion>
-    <FileVersion>2.1.0.0</FileVersion>
+    <AssemblyVersion>3.0.0.0</AssemblyVersion>
+    <FileVersion>3.0.0.0</FileVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>

--- a/Jellyfin.Plugin.Keycloak/KeyCloakAuthenticationProviderPlugin.cs
+++ b/Jellyfin.Plugin.Keycloak/KeyCloakAuthenticationProviderPlugin.cs
@@ -5,14 +5,12 @@ using System.Net.Http;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using Jellyfin.Data.Entities;
-using Jellyfin.Data.Enums;
+using Jellyfin.Database.Implementations.Entities;
 using JWT.Builder;
 using MediaBrowser.Common;
 using MediaBrowser.Common.Net;
 using MediaBrowser.Controller.Authentication;
 using MediaBrowser.Controller.Library;
-using MediaBrowser.Controller.Session;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 
@@ -20,13 +18,14 @@ namespace Jellyfin.Plugin.Keycloak
 {
     /// <summary>
     /// KeyCloak Authentication Provider Plugin.
+    /// Phase 1: Basic authentication only (no role-based permissions yet).
     /// </summary>
     public class KeyCloakAuthenticationProviderPlugin : IAuthenticationProvider
     {
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly ILogger<KeyCloakAuthenticationProviderPlugin> _logger;
         private readonly IApplicationHost _applicationHost;
-        private string _twoFactorPattern = @"(.*)_2FA=(.*)$";
+        private readonly string _twoFactorPattern = @"(.*)_2FA=(.*)$";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="KeyCloakAuthenticationProviderPlugin"/> class.
@@ -44,17 +43,17 @@ namespace Jellyfin.Plugin.Keycloak
             _applicationHost = applicationHost;
         }
 
-        private static bool CreateUser => Plugin.Instance.Configuration.CreateUser;
+        private static bool CreateUser => Plugin.Instance?.Configuration.CreateUser ?? false;
 
-        private static string AuthServerUrl => Plugin.Instance.Configuration.AuthServerUrl;
+        private static string AuthServerUrl => Plugin.Instance?.Configuration.AuthServerUrl ?? string.Empty;
 
-        private static string Realm => Plugin.Instance.Configuration.Realm;
+        private static string Realm => Plugin.Instance?.Configuration.Realm ?? string.Empty;
 
-        private static string Resource => Plugin.Instance.Configuration.Resource;
+        private static string Resource => Plugin.Instance?.Configuration.Resource ?? string.Empty;
 
-        private static string ClientSecret => Plugin.Instance.Configuration.ClientSecret;
+        private static string ClientSecret => Plugin.Instance?.Configuration.ClientSecret ?? string.Empty;
 
-        private static bool Enable2Fa => Plugin.Instance.Configuration.Enable2Fa;
+        private static bool Enable2Fa => Plugin.Instance?.Configuration.Enable2Fa ?? false;
 
         private string TokenUri => $"{AuthServerUrl}/realms/{Realm}/protocol/openid-connect/token";
 
@@ -72,11 +71,14 @@ namespace Jellyfin.Plugin.Keycloak
         private async Task<KeycloakUser?> GetKeycloakUser(string username, string password, string? totp)
         {
             var httpClient = GetHttpClient();
-            var keyValues = new List<KeyValuePair<string, string?>>();
-            keyValues.Add(new KeyValuePair<string, string?>("username", username));
-            keyValues.Add(new KeyValuePair<string, string?>("password", password));
-            keyValues.Add(new KeyValuePair<string, string?>("grant_type", "password"));
-            keyValues.Add(new KeyValuePair<string, string?>("client_id", Resource));
+            var keyValues = new List<KeyValuePair<string, string?>>
+            {
+                new KeyValuePair<string, string?>("username", username),
+                new KeyValuePair<string, string?>("password", password),
+                new KeyValuePair<string, string?>("grant_type", "password"),
+                new KeyValuePair<string, string?>("client_id", Resource)
+            };
+
             if (!string.IsNullOrWhiteSpace(ClientSecret))
             {
                 keyValues.Add(new KeyValuePair<string, string?>("client_secret", ClientSecret));
@@ -89,9 +91,17 @@ namespace Jellyfin.Plugin.Keycloak
 
             var content = new FormUrlEncodedContent(keyValues);
             var response = await httpClient.PostAsync(TokenUri, content).ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("Keycloak authentication failed with status: {Status}", response.StatusCode);
+                return null;
+            }
+
             var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
             KeycloakTokenResponse? parsed = await JsonSerializer.DeserializeAsync<KeycloakTokenResponse>(responseStream).ConfigureAwait(false);
-            if (parsed == null)
+
+            if (parsed?.AccessToken == null)
             {
                 return null;
             }
@@ -100,14 +110,24 @@ namespace Jellyfin.Plugin.Keycloak
             {
                 var jwtToken = JwtBuilder.Create().Decode<IDictionary<string, object>>(parsed.AccessToken);
                 Collection<string> perms = new Collection<string>();
+
                 try
                 {
-                    var resourceAccess = (JObject)jwtToken["resource_access"];
-                    perms = ((JArray)((JObject)resourceAccess[Resource])["roles"]).ToObject<Collection<string>>();
+                    if (jwtToken.TryGetValue("resource_access", out var resourceAccessObj) && resourceAccessObj is JObject resourceAccess)
+                    {
+                        if (resourceAccess[Resource] is JObject clientAccess && clientAccess["roles"] is JArray roles)
+                        {
+                            var rolesList = roles.ToObject<Collection<string>>();
+                            if (rolesList != null)
+                            {
+                                perms = rolesList;
+                            }
+                        }
+                    }
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Could not parse permissions for resource: {Resource}", Resource);
+                    _logger.LogWarning(ex, "Could not parse permissions for resource: {Resource}", Resource);
                 }
 
                 KeycloakUser user = new KeycloakUser(username);
@@ -116,6 +136,7 @@ namespace Jellyfin.Plugin.Keycloak
                     user.Permissions.Add(perm);
                 }
 
+                _logger.LogInformation("Keycloak user {Username} authenticated with permissions: {Permissions}", username, string.Join(", ", perms));
                 return user;
             }
             catch (Exception ex)
@@ -126,39 +147,12 @@ namespace Jellyfin.Plugin.Keycloak
             return null;
         }
 
-        private async Task UpdateUserInfo(KeycloakUser? keycloakUser, User? jellyfinUser)
-        {
-            var userManager = _applicationHost.Resolve<IUserManager>();
-            if (jellyfinUser != null)
-            {
-                jellyfinUser.SetPermission(PermissionKind.IsDisabled, true);
-                jellyfinUser.SetPermission(PermissionKind.IsAdministrator, false);
-                jellyfinUser.SetPermission(PermissionKind.EnableContentDownloading, false);
-                if (keycloakUser != null)
-                {
-                    foreach (string permission in keycloakUser.Permissions)
-                    {
-                        switch (permission)
-                        {
-                            case "administrator":
-                                jellyfinUser.SetPermission(PermissionKind.IsAdministrator, true);
-                                break;
-                            case "allowed_access":
-                                jellyfinUser.SetPermission(PermissionKind.IsDisabled, false);
-                                break;
-                        }
-                    }
-                }
-
-                await userManager.UpdateUserAsync(jellyfinUser).ConfigureAwait(false);
-            }
-        }
-
         /// <inheritdoc />
         public async Task<ProviderAuthenticationResult> Authenticate(string username, string password)
         {
             var userManager = _applicationHost.Resolve<IUserManager>();
             string? totp = null;
+
             if (Enable2Fa)
             {
                 var match = Regex.Match(password, _twoFactorPattern);
@@ -176,7 +170,7 @@ namespace Jellyfin.Plugin.Keycloak
             }
             catch (Exception e)
             {
-                _logger.LogWarning("User Manager could not find a user for Keycloak User, this may not be fatal: {E}", e);
+                _logger.LogDebug(e, "User Manager could not find user {Username}, will create if enabled", username);
             }
 
             KeycloakUser? keycloakUser = await GetKeycloakUser(username, password, totp).ConfigureAwait(false);
@@ -189,15 +183,16 @@ namespace Jellyfin.Plugin.Keycloak
             {
                 if (CreateUser)
                 {
-                    _logger.LogInformation("Creating user: {Username}", username);
+                    _logger.LogInformation("Creating Jellyfin user for Keycloak user: {Username}", username);
                     user = await userManager.CreateUserAsync(username).ConfigureAwait(false);
                     var userAuthenticationProviderId = GetType().FullName;
                     if (userAuthenticationProviderId != null)
                     {
                         user.AuthenticationProviderId = userAuthenticationProviderId;
+                        await userManager.UpdateUserAsync(user).ConfigureAwait(false);
                     }
 
-                    await UpdateUserInfo(keycloakUser, user).ConfigureAwait(false);
+                    // TODO Phase 2: Set permissions based on Keycloak roles
                 }
                 else
                 {
@@ -206,18 +201,8 @@ namespace Jellyfin.Plugin.Keycloak
                         $"Automatic User Creation is disabled and there is no Jellyfin user for authorized Uid: {username}");
                 }
             }
-            else
-            {
-                await UpdateUserInfo(keycloakUser, user).ConfigureAwait(false);
-            }
 
-            if (user != null && user.HasPermission(PermissionKind.IsDisabled))
-            {
-                // If the user no longer has permission to access revoke all sessions for this user
-                _logger.LogInformation("{Username} is disabled, revoking all sessions", username);
-                var sessionHandler = _applicationHost.Resolve<ISessionManager>();
-                await sessionHandler.RevokeUserTokens(user.Id, null).ConfigureAwait(false);
-            }
+            // TODO Phase 2: Update permissions based on Keycloak roles on each login
 
             return new ProviderAuthenticationResult { Username = username };
         }
@@ -231,7 +216,7 @@ namespace Jellyfin.Plugin.Keycloak
         /// <inheritdoc />
         public Task ChangePassword(User user, string newPassword)
         {
-            throw new NotImplementedException();
+            throw new NotImplementedException("Password changes must be done in Keycloak");
         }
     }
 }

--- a/Jellyfin.Plugin.Keycloak/KeyCloakAuthenticationProviderPlugin.cs
+++ b/Jellyfin.Plugin.Keycloak/KeyCloakAuthenticationProviderPlugin.cs
@@ -1,11 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Net.Http;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Jellyfin.Data;
 using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Database.Implementations.Enums;
 using JWT.Builder;
 using MediaBrowser.Common;
 using MediaBrowser.Common.Net;
@@ -18,7 +21,8 @@ namespace Jellyfin.Plugin.Keycloak
 {
     /// <summary>
     /// KeyCloak Authentication Provider Plugin.
-    /// Phase 1: Basic authentication only (no role-based permissions yet).
+    /// Supports authentication via Keycloak Direct Access Grants and
+    /// optional library access sync based on Keycloak roles.
     /// </summary>
     public class KeyCloakAuthenticationProviderPlugin : IAuthenticationProvider
     {
@@ -54,6 +58,33 @@ namespace Jellyfin.Plugin.Keycloak
         private static string ClientSecret => Plugin.Instance?.Configuration.ClientSecret ?? string.Empty;
 
         private static bool Enable2Fa => Plugin.Instance?.Configuration.Enable2Fa ?? false;
+
+        private static bool EnableLibrarySync => Plugin.Instance?.Configuration.EnableLibrarySync ?? false;
+
+        private static Configuration.RoleSource RoleSource => Plugin.Instance?.Configuration.RoleSource ?? Configuration.RoleSource.ClientRoles;
+
+        private static string RoleSourceClient => Plugin.Instance?.Configuration.RoleSourceClient ?? "jellyfin";
+
+        private static string AdminRoles
+        {
+            get
+            {
+                var config = Plugin.Instance?.Configuration;
+                // Fallback to legacy AdminRole if AdminRoles is empty (backwards compatibility)
+                if (string.IsNullOrWhiteSpace(config?.AdminRoles) && !string.IsNullOrWhiteSpace(config?.AdminRole))
+                {
+                    return config.AdminRole;
+                }
+
+                return config?.AdminRoles ?? "administrator";
+            }
+        }
+
+        private static string AllowedAccessRoles => Plugin.Instance?.Configuration.AllowedAccessRoles ?? "allowed_access";
+
+        private static string DownloadRoles => Plugin.Instance?.Configuration.DownloadRoles ?? "allow_media_downloads";
+
+        private static string LibraryRoleMapping => Plugin.Instance?.Configuration.LibraryRoleMapping ?? string.Empty;
 
         private string TokenUri => $"{AuthServerUrl}/realms/{Realm}/protocol/openid-connect/token";
 
@@ -109,34 +140,65 @@ namespace Jellyfin.Plugin.Keycloak
             try
             {
                 var jwtToken = JwtBuilder.Create().Decode<IDictionary<string, object>>(parsed.AccessToken);
-                Collection<string> perms = new Collection<string>();
+                var allRoles = new HashSet<string>();
 
-                try
+                // Read roles based on configured source
+                if (RoleSource == Configuration.RoleSource.ClientRoles)
                 {
-                    if (jwtToken.TryGetValue("resource_access", out var resourceAccessObj) && resourceAccessObj is JObject resourceAccess)
+                    // Read client roles from resource_access.<client>.roles
+                    try
                     {
-                        if (resourceAccess[Resource] is JObject clientAccess && clientAccess["roles"] is JArray roles)
+                        if (jwtToken.TryGetValue("resource_access", out var resourceAccessObj) && resourceAccessObj is JObject resourceAccess)
                         {
-                            var rolesList = roles.ToObject<Collection<string>>();
-                            if (rolesList != null)
+                            var clientName = RoleSourceClient;
+                            if (resourceAccess[clientName] is JObject clientAccess && clientAccess["roles"] is JArray clientRoles)
                             {
-                                perms = rolesList;
+                                foreach (var role in clientRoles.ToObject<List<string>>() ?? new List<string>())
+                                {
+                                    allRoles.Add(role);
+                                }
                             }
                         }
                     }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "Could not parse client roles for client: {Client}", RoleSourceClient);
+                    }
                 }
-                catch (Exception ex)
+                else
                 {
-                    _logger.LogWarning(ex, "Could not parse permissions for resource: {Resource}", Resource);
+                    // Read realm roles from realm_access.roles
+                    try
+                    {
+                        if (jwtToken.TryGetValue("realm_access", out var realmAccessObj) && realmAccessObj is JObject realmAccess)
+                        {
+                            if (realmAccess["roles"] is JArray realmRoles)
+                            {
+                                foreach (var role in realmRoles.ToObject<List<string>>() ?? new List<string>())
+                                {
+                                    allRoles.Add(role);
+                                }
+                            }
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "Could not parse realm roles");
+                    }
                 }
+
+                _logger.LogInformation(
+                    "Keycloak user {Username} authenticated with {RoleSource} roles: {Roles}",
+                    username,
+                    RoleSource,
+                    string.Join(", ", allRoles));
 
                 KeycloakUser user = new KeycloakUser(username);
-                foreach (var perm in perms)
+                foreach (var role in allRoles)
                 {
-                    user.Permissions.Add(perm);
+                    user.Permissions.Add(role);
                 }
 
-                _logger.LogInformation("Keycloak user {Username} authenticated with permissions: {Permissions}", username, string.Join(", ", perms));
                 return user;
             }
             catch (Exception ex)
@@ -145,6 +207,165 @@ namespace Jellyfin.Plugin.Keycloak
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// Parses the library role mapping from JSON config.
+        /// </summary>
+        /// <returns>Dictionary mapping library IDs to required roles.</returns>
+        private Dictionary<Guid, HashSet<string>> ParseLibraryRoleMapping()
+        {
+            var result = new Dictionary<Guid, HashSet<string>>();
+
+            if (string.IsNullOrWhiteSpace(LibraryRoleMapping))
+            {
+                return result;
+            }
+
+            try
+            {
+                var mapping = JObject.Parse(LibraryRoleMapping);
+                foreach (var prop in mapping.Properties())
+                {
+                    if (Guid.TryParse(prop.Name, out var libraryId))
+                    {
+                        var roles = prop.Value.ToString()
+                            .Split(',', StringSplitOptions.RemoveEmptyEntries)
+                            .Select(r => r.Trim().ToLowerInvariant())
+                            .Where(r => !string.IsNullOrEmpty(r))
+                            .ToHashSet();
+
+                        if (roles.Count > 0)
+                        {
+                            result[libraryId] = roles;
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to parse LibraryRoleMapping JSON");
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Parses a comma-separated role string into a HashSet.
+        /// </summary>
+        private static HashSet<string> ParseRoleList(string roleList)
+        {
+            if (string.IsNullOrWhiteSpace(roleList))
+            {
+                return new HashSet<string>();
+            }
+
+            return roleList
+                .Split(',', StringSplitOptions.RemoveEmptyEntries)
+                .Select(r => r.Trim().ToLowerInvariant())
+                .Where(r => !string.IsNullOrEmpty(r))
+                .ToHashSet();
+        }
+
+        /// <summary>
+        /// Checks if user has any of the allowed access roles.
+        /// </summary>
+        private bool HasAllowedAccess(KeycloakUser keycloakUser)
+        {
+            var allowedRoles = ParseRoleList(AllowedAccessRoles);
+            if (allowedRoles.Count == 0)
+            {
+                // No allowed roles configured = everyone allowed
+                return true;
+            }
+
+            var userRoles = keycloakUser.Permissions
+                .Select(p => p.ToLowerInvariant())
+                .ToHashSet();
+
+            return userRoles.Overlaps(allowedRoles);
+        }
+
+        /// <summary>
+        /// Syncs user permissions based on Keycloak roles.
+        /// </summary>
+        private async Task SyncUserPermissions(User user, KeycloakUser keycloakUser, IUserManager userManager)
+        {
+            var userRoles = keycloakUser.Permissions
+                .Select(p => p.ToLowerInvariant())
+                .ToHashSet();
+
+            _logger.LogDebug("Syncing permissions for user {Username} with roles: {Roles}", user.Username, string.Join(", ", userRoles));
+
+            // Check for admin roles
+            var adminRoles = ParseRoleList(AdminRoles);
+            bool shouldBeAdmin = userRoles.Overlaps(adminRoles);
+            if (user.HasPermission(PermissionKind.IsAdministrator) != shouldBeAdmin)
+            {
+                user.SetPermission(PermissionKind.IsAdministrator, shouldBeAdmin);
+                _logger.LogInformation("Set admin status for user {Username} to {IsAdmin}", user.Username, shouldBeAdmin);
+            }
+
+            // Check for download roles
+            var downloadRoles = ParseRoleList(DownloadRoles);
+            bool canDownload = userRoles.Overlaps(downloadRoles);
+            if (user.HasPermission(PermissionKind.EnableContentDownloading) != canDownload)
+            {
+                user.SetPermission(PermissionKind.EnableContentDownloading, canDownload);
+                _logger.LogInformation("Set download permission for user {Username} to {CanDownload}", user.Username, canDownload);
+            }
+
+            // Skip library sync if disabled
+            if (!EnableLibrarySync)
+            {
+                await userManager.UpdateUserAsync(user).ConfigureAwait(false);
+                return;
+            }
+
+            // Parse library mappings
+            var libraryMapping = ParseLibraryRoleMapping();
+            if (libraryMapping.Count == 0)
+            {
+                _logger.LogDebug("No library role mappings configured, skipping library sync");
+                await userManager.UpdateUserAsync(user).ConfigureAwait(false);
+                return;
+            }
+
+            // Calculate which libraries the user should have access to
+            var allowedLibraries = new List<Guid>();
+            foreach (var (libraryId, requiredRoles) in libraryMapping)
+            {
+                bool hasAccess = userRoles.Overlaps(requiredRoles);
+                if (hasAccess)
+                {
+                    allowedLibraries.Add(libraryId);
+                }
+
+                _logger.LogDebug(
+                    "Library {LibraryId}: required roles [{RequiredRoles}], user has access: {HasAccess}",
+                    libraryId,
+                    string.Join(", ", requiredRoles),
+                    hasAccess);
+            }
+
+            // Disable "enable all folders" and set specific folder access
+            user.SetPermission(PermissionKind.EnableAllFolders, false);
+
+            // Clear existing folder preferences and set new ones
+            var currentFolders = user.GetPreferenceValues<Guid>(PreferenceKind.EnabledFolders);
+            var newFolders = allowedLibraries.ToArray();
+
+            // Only update if different
+            if (!currentFolders.SequenceEqual(newFolders))
+            {
+                user.SetPreference(PreferenceKind.EnabledFolders, newFolders);
+                _logger.LogInformation(
+                    "Updated library access for user {Username}: {Libraries}",
+                    user.Username,
+                    string.Join(", ", allowedLibraries));
+            }
+
+            await userManager.UpdateUserAsync(user).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -179,6 +400,17 @@ namespace Jellyfin.Plugin.Keycloak
                 throw new AuthenticationException("Error completing Keycloak login. Invalid username or password.");
             }
 
+            // Check if user has required access roles
+            if (!HasAllowedAccess(keycloakUser))
+            {
+                _logger.LogWarning(
+                    "Keycloak user {Username} denied: missing required access roles. User roles: [{UserRoles}], Required: [{RequiredRoles}]",
+                    username,
+                    string.Join(", ", keycloakUser.Permissions),
+                    AllowedAccessRoles);
+                throw new AuthenticationException("Access denied. You don't have the required roles to access Jellyfin.");
+            }
+
             if (user == null)
             {
                 if (CreateUser)
@@ -192,7 +424,8 @@ namespace Jellyfin.Plugin.Keycloak
                         await userManager.UpdateUserAsync(user).ConfigureAwait(false);
                     }
 
-                    // TODO Phase 2: Set permissions based on Keycloak roles
+                    // Sync permissions for new user
+                    await SyncUserPermissions(user, keycloakUser, userManager).ConfigureAwait(false);
                 }
                 else
                 {
@@ -201,8 +434,11 @@ namespace Jellyfin.Plugin.Keycloak
                         $"Automatic User Creation is disabled and there is no Jellyfin user for authorized Uid: {username}");
                 }
             }
-
-            // TODO Phase 2: Update permissions based on Keycloak roles on each login
+            else
+            {
+                // Sync permissions for existing user on each login
+                await SyncUserPermissions(user, keycloakUser, userManager).ConfigureAwait(false);
+            }
 
             return new ProviderAuthenticationResult { Username = username };
         }

--- a/Jellyfin.Plugin.Keycloak/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.Keycloak/PluginServiceRegistrator.cs
@@ -1,0 +1,19 @@
+using MediaBrowser.Controller;
+using MediaBrowser.Controller.Authentication;
+using MediaBrowser.Controller.Plugins;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Jellyfin.Plugin.Keycloak
+{
+    /// <summary>
+    /// Register Keycloak authentication provider with Jellyfin's DI container.
+    /// </summary>
+    public class PluginServiceRegistrator : IPluginServiceRegistrator
+    {
+        /// <inheritdoc />
+        public void RegisterServices(IServiceCollection serviceCollection, IServerApplicationHost applicationHost)
+        {
+            serviceCollection.AddSingleton<IAuthenticationProvider, KeyCloakAuthenticationProviderPlugin>();
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -6,22 +6,39 @@ A plugin for Jellyfin to authenticate users against a Keycloak instance using Di
 
 | Plugin Version | Jellyfin Version | .NET Version |
 |----------------|------------------|--------------|
-| 2.1.x          | 10.11.x          | .NET 9       |
+| 3.0.x          | 10.11.x          | .NET 9       |
 | 2.0.x          | 10.8.x           | .NET 6       |
 | 1.x            | 10.7.x           | .NET 5       |
+
+## Features
+
+- **Flexible Role Source:** Choose between Keycloak Client Roles or Realm Roles
+- **Configurable Permission Mapping:** Map any Keycloak role to Jellyfin permissions
+- **Library Access Sync:** Automatically sync library access based on Keycloak roles
+- **Backwards Compatible:** Default configuration works with existing setups
 
 ## Requirements
 
 * Keycloak client with `Direct Access Grants Enabled`
-* The following roles defined on your Keycloak client:
-  - `administrator` - Grants admin access in Jellyfin
-  - `allowed_access` - Required to log in to Jellyfin
-  - `allow_media_downloads` - Allows media downloads
-* Map at least `allowed_access` to users who should access Jellyfin (directly or via group)
+* Roles configured in Keycloak (Client Roles or Realm Roles)
+
+### Default Role Names (Backwards Compatible)
+
+If you don't change the default configuration:
+- `administrator` - Grants admin access in Jellyfin
+- `allowed_access` - Required to log in to Jellyfin
+- `allow_media_downloads` - Allows media downloads
+
+### Custom Role Names
+
+You can configure any role names in the plugin settings. For example:
+- Admin Roles: `admin, superuser`
+- Allowed Access Roles: `user, member, admin`
+- Download Roles: `premium, admin`
 
 ## Limitations
 
-* **No token renewal/revoking:** If you delete/invalidate a user's session in Keycloak, the Jellyfin session remains active. However, if you remove the `allowed_access` role and the user logs in again, all Jellyfin sessions are revoked.
+* **No token renewal/revoking:** If you delete/invalidate a user's session in Keycloak, the Jellyfin session remains active. However, if you remove the access role and the user logs in again, all Jellyfin sessions are revoked.
 
 * **No true SSO:** Users must authenticate to Jellyfin even if already signed into the Keycloak realm.
 
@@ -62,14 +79,52 @@ dotnet publish -c Release Jellyfin.Plugin.Keycloak/Jellyfin.Plugin.Keycloak.cspr
 
 ## Configuration
 
+### Keycloak Connection
+
 | Setting | Description |
 |---------|-------------|
 | Auth Server URL | Your Keycloak server URL (e.g., `https://auth.example.com/auth`) |
 | Realm | The Keycloak realm name |
 | Resource (Client ID) | The Keycloak client ID |
-| Client Secret | The client secret (if confidential client) |
+| Client Secret | The client secret (leave empty for public clients) |
+
+### User Settings
+
+| Setting | Description |
+|---------|-------------|
 | Create User | Auto-create Jellyfin users for new Keycloak users |
-| Enable 2FA | Require 2FA for login (if configured in Keycloak) |
+| Enable 2FA | Append `_2FA=CODE` to password for TOTP |
+
+### Role Configuration
+
+| Setting | Description |
+|---------|-------------|
+| Role Source | Where to read roles from: Client Roles or Realm Roles |
+| Client Name for Roles | Client name when using Client Roles (default: same as Resource) |
+
+### Permission Mapping
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| Admin Roles | Roles that grant Jellyfin admin status | `administrator` |
+| Allowed Access Roles | Roles required to log in | `allowed_access` |
+| Download Roles | Roles that allow media downloads | `allow_media_downloads` |
+
+### Library Access Sync
+
+| Setting | Description |
+|---------|-------------|
+| Enable Library Sync | Sync library access based on roles on each login |
+| Library Role Mapping | For each library, specify which roles have access |
+
+## Upgrading from v2.x
+
+The plugin is backwards compatible. Your existing configuration will continue to work.
+
+New features are opt-in:
+- Role Source defaults to Client Roles
+- Permission roles default to the original role names
+- Library Sync is disabled by default
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,28 +1,76 @@
 # Keycloak Authentication Plugin
 
-A simple plugin for Jellyfin to authenticate against a Keycloak instance.  
-  
+A plugin for Jellyfin to authenticate users against a Keycloak instance using Direct Access Grants.
+
+## Compatibility
+
+| Plugin Version | Jellyfin Version | .NET Version |
+|----------------|------------------|--------------|
+| 2.1.x          | 10.11.x          | .NET 9       |
+| 2.0.x          | 10.8.x           | .NET 6       |
+| 1.x            | 10.7.x           | .NET 5       |
+
 ## Requirements
-* Your keycloak client config needs to have `Direct Access Grants Enabled` enabled.
-* You need to add the following roles your defined client `administrator`, `allowed_access`, `allow_media_downloads`
-* Map at least `allowed_access` to the users you want to be able to access jellyfin (or map it to a group)
-  
+
+* Keycloak client with `Direct Access Grants Enabled`
+* The following roles defined on your Keycloak client:
+  - `administrator` - Grants admin access in Jellyfin
+  - `allowed_access` - Required to log in to Jellyfin
+  - `allow_media_downloads` - Allows media downloads
+* Map at least `allowed_access` to users who should access Jellyfin (directly or via group)
 
 ## Limitations
-* This only provides a an authentication method against Keycloak, it does not handle token renewal/revoking.  
-eg: If you delete/invalidate/etc a users session/account in keycloak the session will remain active in Jellyfin.  
-(However  if you remove the `allowed_access` role and the user logs in again all sessions in Jellyfin are revoked.)  
 
-* It does not provide a true 'Single Sign On' as if the user is signed into the Realm already the user will still be prompted to authenticate to Jellyfin.  
-  
-* It does not follow oauth2 or oidc worflow, it mearly requests a token from keycloak with the username/password provided if we get a token we mark the authentication request as successfull.
+* **No token renewal/revoking:** If you delete/invalidate a user's session in Keycloak, the Jellyfin session remains active. However, if you remove the `allowed_access` role and the user logs in again, all Jellyfin sessions are revoked.
 
-## Build/Installation
-1. Have .NET SDK 5.0
-2. `dotnet publish --configuration Release --output bin`
-3. Make a directory called `keycloak` (or whatever you want) in your jellyfin keycloak directory  
-Windows: `%localappdata%\jellyfin\plugins`  
-Linux: `/var/lib/jellyfin/plugins`  
-Place the built `Jellyfin.Plugin.Keycloak.dll` and `JWT.dll` in the directory and restart Jellyfin
-4. Configure the plugin in the webui `Admin Dashboard -> Advanced -> Plugins`
+* **No true SSO:** Users must authenticate to Jellyfin even if already signed into the Keycloak realm.
 
+* **Not OAuth2/OIDC:** This plugin validates username/password via Direct Access Grants (Resource Owner Password Credentials). This allows authentication from ALL clients (TV apps, mobile apps, web) without browser redirects.
+
+## Build
+
+### Using Docker (recommended)
+
+```bash
+# Build with .NET 9 SDK container
+docker run --rm -v "$(pwd):/src" -w /src mcr.microsoft.com/dotnet/sdk:9.0 \
+  dotnet publish -c Release Jellyfin.Plugin.Keycloak/Jellyfin.Plugin.Keycloak.csproj -o /src/publish
+```
+
+### Using local .NET SDK
+
+```bash
+# Requires .NET 9 SDK installed
+dotnet publish -c Release Jellyfin.Plugin.Keycloak/Jellyfin.Plugin.Keycloak.csproj -o publish
+```
+
+## Installation
+
+1. Create a directory called `Keycloak` in your Jellyfin plugins directory:
+   - Linux: `/var/lib/jellyfin/plugins/Keycloak/`
+   - Windows: `%localappdata%\jellyfin\plugins\Keycloak\`
+   - Docker: `<config-volume>/plugins/Keycloak/`
+
+2. Copy the following files from `publish/`:
+   - `Jellyfin.Plugin.Keycloak.dll`
+   - `JWT.dll`
+   - `Newtonsoft.Json.dll`
+
+3. Restart Jellyfin
+
+4. Configure the plugin in: **Admin Dashboard -> Plugins -> Keycloak-Auth**
+
+## Configuration
+
+| Setting | Description |
+|---------|-------------|
+| Auth Server URL | Your Keycloak server URL (e.g., `https://auth.example.com/auth`) |
+| Realm | The Keycloak realm name |
+| Resource (Client ID) | The Keycloak client ID |
+| Client Secret | The client secret (if confidential client) |
+| Create User | Auto-create Jellyfin users for new Keycloak users |
+| Enable 2FA | Require 2FA for login (if configured in Keycloak) |
+
+## License
+
+GPL-3.0 - See [LICENSE](LICENSE) for details.

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Build Jellyfin Keycloak Auth Plugin using Docker
+# Usage: ./build.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "=== Jellyfin Keycloak Auth Plugin Build ==="
+echo ""
+
+# Clean previous build
+echo "[1/2] Cleaning previous build..."
+rm -rf "$SCRIPT_DIR/publish" "$SCRIPT_DIR/Jellyfin.Plugin.Keycloak/bin" "$SCRIPT_DIR/Jellyfin.Plugin.Keycloak/obj"
+
+# Build with Docker
+echo "[2/2] Building with .NET 9 SDK (Docker)..."
+docker run --rm -v "$SCRIPT_DIR:/src" -w /src mcr.microsoft.com/dotnet/sdk:9.0 \
+  dotnet publish -c Release Jellyfin.Plugin.Keycloak/Jellyfin.Plugin.Keycloak.csproj -o /src/publish
+
+# Check build success
+if [ ! -f "$SCRIPT_DIR/publish/Jellyfin.Plugin.Keycloak.dll" ]; then
+  echo "Build failed!"
+  exit 1
+fi
+
+echo ""
+echo "=== Build successful ==="
+echo ""
+echo "Output files in publish/:"
+ls -la "$SCRIPT_DIR/publish/"*.dll
+echo ""
+echo "Copy these files to your Jellyfin plugins directory:"
+echo "  - Jellyfin.Plugin.Keycloak.dll"
+echo "  - JWT.dll"
+echo "  - Newtonsoft.Json.dll"

--- a/build.yaml
+++ b/build.yaml
@@ -1,16 +1,20 @@
 ---
 name: "Keycloak Authentication"
 guid: "40886866-b3dd-4d6a-bf9b-25c83e6c3d10"
-version: "1.0.0.0"
-targetAbi: "10.7.0.0"
-framework: "net5.0"
+version: "3.0.0.0"
+targetAbi: "10.11.0.0"
+framework: "net9.0"
 overview: "Authenticate users against Keycloak"
 description: >
-  Authenticate users against Keycloak.
+  Authenticate users against Keycloak with support for Realm and Client roles,
+  configurable permission mapping (Admin, Access, Download), and library access sync.
 category: "Authentication"
 owner: "Ugrend"
 artifacts:
 - "Jellyfin.Plugin.Keycloak.dll"
 - "JWT.dll"
+- "Newtonsoft.Json.dll"
 changelog: >
-  changelog
+  v3.0.0.0: Updated for Jellyfin 10.11+ (net9.0), added configurable Role Source
+  (Realm/Client roles), permission mapping (Admin/Access/Download roles),
+  and library access sync based on Keycloak roles.


### PR DESCRIPTION
## Summary

This PR updates the plugin for Jellyfin 10.11+ and adds configurable role-based permissions.

### Breaking Changes
- None - fully backwards compatible with existing configurations

### New Features
- **Role Source Selection**: Choose between Client Roles (`resource_access.<client>.roles`) or Realm Roles (`realm_access.roles`)
- **Configurable Permission Mapping**: Map any Keycloak role names to Jellyfin permissions (Admin, Allowed Access, Download)
- **Library Access Sync**: Automatically sync library access based on Keycloak roles on each login

### Improvements
- Updated for Jellyfin 10.11.x (.NET 9, targetAbi 10.11.0.0)
- Legacy `AdminRole` config field migrates automatically to new `AdminRoles` field
- Comprehensive README with all configuration options

## Compatibility

| Plugin Version | Jellyfin Version | .NET Version |
|----------------|------------------|--------------|
| 3.0.x          | 10.11.x          | .NET 9       |
| 2.0.x          | 10.8.x           | .NET 6       |
| 1.x            | 10.7.x           | .NET 5       |

## Testing

Tested with:
- Jellyfin 10.11.x
- Keycloak 26.x
- Both Realm Roles and Client Roles configurations
- Library sync with multiple libraries and role mappings